### PR TITLE
Added libsodium check.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -951,6 +951,7 @@ if test x$use_pkgconfig = xyes; then
     [
       PKG_CHECK_MODULES([SSL], [libssl],, [AC_MSG_ERROR(openssl  not found.)])
       PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto  not found.)])
+      PKG_CHECK_MODULES([SODIUM], [libsodium],,[AC_MSG_ERROR(libsodium  not found.)])
       BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes], [BITCOIN_QT_FAIL(libprotobuf not found)])])
       if test x$use_qr != xno; then
         BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])


### PR DESCRIPTION
Added checking for libsodium library in configure.ac. The command `./configure` will fail and issue an error message if libsodium is not installed on the build machine.
