### PR TITLE
Idb fix

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -33,6 +33,12 @@ static const int CONTINUE_EXECUTION=-1;
 
 // To fix the chainActive not defined error.
 CChain chainActive;
+struct BlockHasher
+{
+    size_t operator()(const uint256& hash) const { return hash.GetCheapHash(); }
+};
+typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
+BlockMap mapBlockIndex;
 
 //
 // This function returns either one of EXIT_ codes when it's expected to stop the process or

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -33,12 +33,8 @@ static const int CONTINUE_EXECUTION=-1;
 
 // To fix the chainActive not defined error.
 CChain chainActive;
-struct BlockHasher
-{
-    size_t operator()(const uint256& hash) const { return hash.GetCheapHash(); }
-};
-typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
-BlockMap mapBlockIndex;
+typedef std::map<uint64_t, CBlockIndex*> BlockSeedHeightMap;
+BlockSeedHeightMap mapBlockSeedHeight;
 
 //
 // This function returns either one of EXIT_ codes when it's expected to stop the process or

--- a/src/cn_utils/crypto/hash-ops.h
+++ b/src/cn_utils/crypto/hash-ops.h
@@ -93,5 +93,6 @@ void rx_slow_hash_allocate_state(void);
 void rx_slow_hash_free_state(void);
 uint64_t rx_seedheight(const uint64_t height);
 void rx_seedheights(const uint64_t height, uint64_t *seed_height, uint64_t *next_height);
+int is_a_seed_height(const uint64_t height);
 void rx_slow_hash(const uint64_t mainheight, const uint64_t seedheight, const char *seedhash, const void *data, size_t length, char *hash, int miners, int is_alt);
 void rx_reorg(const uint64_t split_height);

--- a/src/cn_utils/crypto/rx-slow-hash.c
+++ b/src/cn_utils/crypto/rx-slow-hash.c
@@ -139,6 +139,11 @@ void rx_seedheights(const uint64_t height, uint64_t *seedheight, uint64_t *nexth
   *nextheight = rx_seedheight(height + SEEDHASH_EPOCH_LAG);
 }
 
+int is_a_seed_height(const uint64_t height) {
+    uint64_t next_seed_hegith = rx_seedheight(height + SEEDHASH_EPOCH_LAG + 1);
+    return (height == next_seed_hegith);
+}
+
 typedef struct seedinfo {
   randomx_cache *si_cache;
   unsigned long si_start;

--- a/src/validation.h
+++ b/src/validation.h
@@ -161,6 +161,8 @@ extern CBlockPolicyEstimator feeEstimator;
 extern CTxMemPool mempool;
 typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap& mapBlockIndex;
+typedef std::map<uint64_t, CBlockIndex*> BlockSeedHeightMap;
+extern BlockSeedHeightMap& mapBlockSeedHeight;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockWeight;
 extern const std::string strMessageMagic;
@@ -221,7 +223,7 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
-/** 
+/**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
@@ -232,7 +234,7 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  *
  * Note that we guarantee that either the proof-of-work is valid on pblock, or
  * (and possibly also) BlockChecked will have been called.
- * 
+ *
  * Call without cs_main held.
  *
  * @param[in]   pblock  The block we want to process.
@@ -358,7 +360,7 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = null
 
 /**
  * Closure representing one script verification
- * Note that this stores references to the spending transaction 
+ * Note that this stores references to the spending transaction
  */
 class CScriptCheck
 {


### PR DESCRIPTION
Fixed Initial block download (IDB) crash. The chainActive does not contain any blocks during IDB. We must save the block hash for these blocks that are candidates of seeds.

Fixed calling params to rx_slow_hash. Set miners to 0 to prevent incorrect results.