### PR TITLE
add kex.keva.one dns seed

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -170,6 +170,9 @@ public:
         // Note that of those with the service bits flag, most only support a subset of possible options
         vSeeds.emplace_back("dnsseed.kevacoin.org");
 
+        // Third party DNS
+        vSeeds.emplace_back("kex.keva.one"); // by https://bitcointalk.org/index.php?topic=5213046.msg63803088#msg63803088
+
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,45); // K
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
         base58Prefixes[SCRIPT_ADDRESS2] = std::vector<unsigned char>(1,70); // V


### PR DESCRIPTION
Appended reserve DNS resolver by:

https://bitcointalk.org/index.php?topic=5213046.msg63803088#msg63803088

This update already included in `kvazar` branch at:
https://github.com/kvazar-network/kevacoin/tree/kvazar