### PR TITLE
fix EnableHighDpiScaling init

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -561,7 +561,6 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin);
     Q_INIT_RESOURCE(bitcoin_locale);
 
-    BitcoinApplication app(argc, argv);
 #if QT_VERSION > 0x050100
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
@@ -572,6 +571,8 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif
+
+    BitcoinApplication app(argc, argv);
 
     // Register meta types used for QMetaObject::invokeMethod
     qRegisterMetaType< bool* >();


### PR DESCRIPTION
Solved notice on application launch:

```
Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.
```

This update already included in `kvazar` branch at:
https://github.com/kvazar-network/kevacoin/tree/kvazar