### PR TITLE
disable save button on key/value length limit reached #7

### DIFF
--- a/src/qt/forms/kevaaddkeydialog.ui
+++ b/src/qt/forms/kevaaddkeydialog.ui
@@ -15,16 +15,33 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout">
             <item>
-                <widget class="QLabel" name="label_1">
-                    <property name="text">
-                        <string>Key</string>
-                    </property>
-                </widget>
+                <layout class="QGridLayout" name="gridKeyLableLayout">
+                    <item column="1">
+                        <widget class="QLabel" name="keyLable">
+                            <property name="text">
+                                <string>Key</string>
+                            </property>
+                            <property name="alignment">
+                                <set>Qt::AlignLeft</set>
+                            </property>
+                        </widget>
+                    </item>
+                    <item column="2">
+                        <widget class="QLabel" name="keyCounter">
+                            <property name="text">
+                                <string/>
+                            </property>
+                            <property name="alignment">
+                                <set>Qt::AlignRight</set>
+                            </property>
+                        </widget>
+                    </item>
+                </layout>
             </item>
             <item>
                 <widget class="QLineEdit" name="keyText">
                     <property name="toolTip">
-                        <string>New value</string>
+                        <string>New key</string>
                     </property>
                 </widget>
             </item>
@@ -42,11 +59,28 @@
                 </spacer>
             </item>
             <item>
-                <widget class="QLabel" name="label_2">
-                    <property name="text">
-                        <string>Value</string>
-                    </property>
-                </widget>
+                <layout class="QGridLayout" name="gridValueLableLayout">
+                    <item column="1">
+                        <widget class="QLabel" name="valueLabel">
+                            <property name="text">
+                                <string>Value</string>
+                            </property>
+                            <property name="alignment">
+                                <set>Qt::AlignLeft</set>
+                            </property>
+                        </widget>
+                    </item>
+                    <item column="2">
+                        <widget class="QLabel" name="valueCounter">
+                            <property name="text">
+                                <string/>
+                            </property>
+                            <property name="alignment">
+                                <set>Qt::AlignRight</set>
+                            </property>
+                        </widget>
+                    </item>
+                </layout>
             </item>
             <item>
                 <widget class="QPlainTextEdit" name="valueText">

--- a/src/qt/kevaaddkeydialog.cpp
+++ b/src/qt/kevaaddkeydialog.cpp
@@ -67,7 +67,7 @@ void KevaAddKeyDialog::onKeyChanged(const QString& key)
 
     keyCounterPalette.setColor(
         QPalette::WindowText,
-        keyTextLength > MAX_SCRIPT_ELEMENT_SIZE ? Qt::red : Qt::darkGreen
+        keyTextLength > 255 ? Qt::red : Qt::darkGreen
     );
 
     ui->keyCounter->setPalette(

--- a/src/qt/kevaaddkeydialog.cpp
+++ b/src/qt/kevaaddkeydialog.cpp
@@ -49,12 +49,16 @@ void KevaAddKeyDialog::cancel()
 
 void KevaAddKeyDialog::onKeyChanged(const QString& key)
 {
-    bool enabled = key.length() > 0 && ui->valueText->toPlainText().length() > 0;
+    bool enabled = key.length() > 0    && ui->valueText->toPlainText().length() > 0 &&
+                   key.length() <= 255 && ui->valueText->toPlainText().length() < MAX_SCRIPT_ELEMENT_SIZE + 1;
+
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(enabled);
 }
 
 void KevaAddKeyDialog::onValueChanged()
 {
-    bool enabled = ui->valueText->toPlainText().length() > 0 && ui->keyText->text().length() > 0;
+    bool enabled = ui->keyText->text().length() > 0    && ui->valueText->toPlainText().length() > 0 &&
+                   ui->keyText->text().length() <= 255 && ui->valueText->toPlainText().length() < MAX_SCRIPT_ELEMENT_SIZE + 1;
+
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(enabled);
 }

--- a/src/qt/kevaaddkeydialog.cpp
+++ b/src/qt/kevaaddkeydialog.cpp
@@ -49,16 +49,68 @@ void KevaAddKeyDialog::cancel()
 
 void KevaAddKeyDialog::onKeyChanged(const QString& key)
 {
-    bool enabled = key.length() > 0    && ui->valueText->toPlainText().length() > 0 &&
-                   key.length() <= 255 && ui->valueText->toPlainText().length() < MAX_SCRIPT_ELEMENT_SIZE + 1;
+    // Calculate current length
+    int keyTextLength   = key.length();
+    int valueTextLength = ui->valueText->toPlainText().length();
+
+    // Update counter value
+    ui->keyCounter->setText(
+        QString::number(
+            keyTextLength
+        ) + "/" + QString::number(
+            255
+        )
+    );
+
+    // Update counter palette
+    QPalette keyCounterPalette = ui->keyCounter->palette();
+
+    keyCounterPalette.setColor(
+        QPalette::WindowText,
+        keyTextLength > MAX_SCRIPT_ELEMENT_SIZE ? Qt::red : Qt::darkGreen
+    );
+
+    ui->keyCounter->setPalette(
+        keyCounterPalette
+    );
+
+    // Update button status
+    bool enabled = keyTextLength > 0    && valueTextLength > 0 &&
+                   keyTextLength <= 255 && valueTextLength < MAX_SCRIPT_ELEMENT_SIZE + 1;
 
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(enabled);
 }
 
 void KevaAddKeyDialog::onValueChanged()
 {
-    bool enabled = ui->keyText->text().length() > 0    && ui->valueText->toPlainText().length() > 0 &&
-                   ui->keyText->text().length() <= 255 && ui->valueText->toPlainText().length() < MAX_SCRIPT_ELEMENT_SIZE + 1;
+    // Calculate current length
+    int keyTextLength   = ui->keyText->text().length();
+    int valueTextLength = ui->valueText->toPlainText().length();
+
+    // Update counter value
+    ui->valueCounter->setText(
+        QString::number(
+            valueTextLength
+        ) + "/" + QString::number(
+            MAX_SCRIPT_ELEMENT_SIZE
+        )
+    );
+
+    // Update counter palette
+    QPalette valueCounterPalette = ui->valueCounter->palette();
+
+    valueCounterPalette.setColor(
+        QPalette::WindowText,
+        valueTextLength > MAX_SCRIPT_ELEMENT_SIZE ? Qt::red : Qt::darkGreen
+    );
+
+    ui->valueCounter->setPalette(
+        valueCounterPalette
+    );
+
+    // Update button status
+    bool enabled = keyTextLength > 0    && valueTextLength > 0 &&
+                   keyTextLength <= 255 && valueTextLength < MAX_SCRIPT_ELEMENT_SIZE + 1;
 
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(enabled);
 }


### PR DESCRIPTION
I've dream about this feature for a long time and finally implemented!

* [x] Send button deactivation on limits reached
* [x] Length counter for key / values
* [x] Colorized highlight (green / red) or hidden on empty

This and other all PR also included to `kvazar` branch at:
https://github.com/kvazar-network/kevacoin/tree/kvazar

Still sending contributions here anyway!